### PR TITLE
remove getLastError() function that is later overwritten

### DIFF
--- a/src/antimony_binding.jl
+++ b/src/antimony_binding.jl
@@ -272,14 +272,6 @@ end
 ###################################################################################################
 
 
-"""
-  antimony_getLastError()
-When any function returns an error condition, a longer description of the problem is
-stored in memory, and is obtainable with this function.
-"""
-function getLastError()
-  return unsafe_string(ccall(dlsym(antlib, :getLastError), cdecl, Ptr{UInt8}, ()))
-end
 
 """
   getWarnings()


### PR DESCRIPTION
The getLastError() function in antimony_bindings.jl is overwritten in RoadRunner.jl. This makes RoadRunner throw a Warning message every time it is loaded. 