### PR TITLE
Fix the bug with freeing the memory when calling getAntiomny and getCurrentAntiomy functions

### DIFF
--- a/src/antimony_binding.jl
+++ b/src/antimony_binding.jl
@@ -185,9 +185,7 @@ end
 Returns the same output as writeAntimonyFile, but to a char* array instead of to a file.
 """
 function getAntimonyString(moduleName::String)
-  char_pointer=ccall(dlsym(antlib, :getAntimonyString), cdecl, Ptr{UInt8}, (Ptr{UInt8},), moduleName)
-  julia_str=unsafe_string(char_pointer)
-  return julia_str
+  return unsafe_string(ccall(dlsym(antlib, :getAntimonyString), cdecl, Ptr{UInt8}, (Ptr{UInt8},), moduleName))
 end
 
 """

--- a/src/antimony_binding.jl
+++ b/src/antimony_binding.jl
@@ -187,7 +187,6 @@ Returns the same output as writeAntimonyFile, but to a char* array instead of to
 function getAntimonyString(moduleName::String)
   char_pointer=ccall(dlsym(antlib, :getAntimonyString), cdecl, Ptr{UInt8}, (Ptr{UInt8},), moduleName)
   julia_str=unsafe_string(char_pointer)
-  freeText(char_pointer)
   return julia_str
 end
 


### PR DESCRIPTION
In getAntimonyString we no longer call freeText to free the memory allocated to the antimony string we retrieved as it is freed at some point and leads to a 'double free detected' error.